### PR TITLE
Poprawka?

### DIFF
--- a/ProgramRobot/robot.c
+++ b/ProgramRobot/robot.c
@@ -317,6 +317,6 @@ void initialize()
 	// TCCR1B=(1<WGM12)|(1 << CS11);
 
 	TCCR1A = (1 << COM1A1) | (1 << COM1B1) | (1 << WGM11);
-	TCCR1B = (1 << WGM13) | (1<WGM12) | (1 << CS10);
+	TCCR1B = (1 << WGM13) | (1 << WGM12) | (1 << CS10);
 }
 


### PR DESCRIPTION
O ile to celowe nie było. Chyba ustawiało CS10 (bo 1<4 to 1), czyli nic nie robiło.

Nie jestem jeszcze pewien jak dużo Fast PWM zmienia, ale z tego co czytam aż taka wielka nie jest.
